### PR TITLE
Use registry.k8s.io/pause:3.9 instead of registry.k8s.io/pause:latest

### DIFF
--- a/images/toolbox/Dockerfile
+++ b/images/toolbox/Dockerfile
@@ -54,9 +54,7 @@ COPY VERSION /VERSION
 # This is convenient when using this Docker image to run a K8s Pod which is meant to be exec'ed
 # into, as there is no need to specify an explicit command when deploying the Pod.
 # "pause" is superior to a simple "sleep infinity", as it handled signals correctly.
-# We use the "latest" tag, and the binary will be updated (if needed) every time this image is
-# re-built.
 # Note that pause is a static binary.
-COPY --from=registry.k8s.io/pause:latest /pause /pause
+COPY --from=registry.k8s.io/pause:3.9 /pause /pause
 
 CMD ["/pause"]


### PR DESCRIPTION
registry.k8s.io/pause:latest is not actually a multi-platform manifest list. As a result, the pause binary included in the toolbox image was not valid on arm platforms (arm64 and arm/v7).

Fixes #28