### PR TITLE
Migrate the Dependabot configuration to a Renovate configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,12 @@ updates:
     ignore:
       # this should update the image sha, but not the tag
       - dependency-name: ubuntu
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
+    open-pull-requests-limit: 0 # Disable Dependabot from creating PRs
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0 # Disable Dependabot from creating PRs

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,6 +14,11 @@
 
   labels: ["dependencies"],
 
+  // Only make PRs for security vulnerability alerts
+  vulnerabilityAlerts: {
+    enabled: true,
+  },
+
   packageRules: [
     {
       matchManagers: ["dockerfile"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,37 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "config:base",
+    ":gitSignOff", // Add commit Sign-Off for renovate commits
+  ],
+
+  // Allow only certain package managers and implicitly disable all others
+  enabledManagers: ["dockerfile", "github-actions"],
+
+  baseBranches: ["main"],
+  prConcurrentLimit: 5,
+  prHourlyLimit: 0,
+
+  labels: ["dependencies"],
+
+  packageRules: [
+    {
+      matchManagers: ["dockerfile"],
+      matchFileNames: ["images/toolbox/*"],
+      addLabels: ["docker"],
+    },
+
+    // this should update the image sha, but not the tag
+    {
+      matchManagers: ["dockerfile"],
+      matchPackageNames: ["ubuntu"],
+      matchUpdateTypes: ["major", "minor"],
+      enabled: false,
+    },
+
+    {
+      matchManagers: ["github-actions"],
+      addLabels: ["github_actions"],
+    },
+  ],
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,6 +20,7 @@
   },
 
   packageRules: [
+    // Limiting Docker updates to certain path
     {
       matchManagers: ["dockerfile"],
       enabled: false,

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,7 +14,7 @@
 
   labels: ["dependencies"],
 
-  // Only make PRs for security vulnerability alerts
+  // Enabling security updates based on GitHub's Dependabot-style security alerts
   vulnerabilityAlerts: {
     enabled: true,
   },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,7 +23,8 @@
     {
       matchManagers: ["dockerfile"],
       enabled: false,
-    }
+    },
+
     {
       matchManagers: ["dockerfile"],
       matchFileNames: ["images/toolbox/*"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,8 +22,13 @@
   packageRules: [
     {
       matchManagers: ["dockerfile"],
+      enabled: false,
+    }
+    {
+      matchManagers: ["dockerfile"],
       matchFileNames: ["images/toolbox/*"],
       addLabels: ["docker"],
+      enabled: true,
     },
 
     // this should update the image sha, but not the tag


### PR DESCRIPTION
Migrated dependency updates from Dependabot to Renovate and disabled Dependabot from opening PRs.