### PR TITLE
chore: remove redundant enabled: true from renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,7 +30,6 @@
       matchManagers: ["dockerfile"],
       matchFileNames: ["images/toolbox/*"],
       addLabels: ["docker"],
-      enabled: true,
     },
 
     // this should update the image sha, but not the tag


### PR DESCRIPTION
Remove redundant `enabled: true` declarations from Renovate configuration for consistent configuration.